### PR TITLE
Added an accessor to get the fields as they're explicitly ordered.

### DIFF
--- a/forms.go
+++ b/forms.go
@@ -26,6 +26,10 @@ func (self *Fields) GetMap() map[string]Field {
 	return self.fieldsMap
 }
 
+func (self *Fields) GetOrderedFields() []Field {
+        return self.fields
+}
+
 func (self *Fields) AddField(field Field) bool {
 	name := field.GetName()
 	_, exists := self.NamedBy(name)


### PR DESCRIPTION
I wanted to use the fields with a custom renderer (much in the way that examples/html.go does), but maps are not stable in Go ( per here: http://blog.golang.org/go-maps-in-action ).  This accessor makes it so I can use the stable fields without having to store them myself (especially if the form is built of multiple AddField calls).
