### PR TITLE
TextWidget now reuses the last submitted value.

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -7,7 +7,7 @@ import (
 const defaultTemplates = `
 {{define "TextTypeField"}}<input type="text" name="{{.Field.GetName}}" value="{{.Value | html}}"></input>{{end}}
 
-{{define "TextWidget"}}<input type="text" name="{{.Name}}" value=""{{range $attr, $val := .Attrs}} {{$attr}}="{{$val}}"{{end}}></input>{{end}}
+{{define "TextWidget"}}<input type="text" name="{{.Name}}" value="{{range $val := .Value}}{{$val | html}}{{ end }}"{{range $attr, $val := .Attrs}} {{$attr}}="{{$val}}"{{end}}></input>{{end}}
 
 {{define "SelectWidget"}}<select name="{{.Name}}"{{range $attr, $val := .Attrs}}{{$attr}}="{{$val}}"{{end}}>
 {{range $idx, $val := .Options}}<option value="{{$val.Value | html}}"{{if $val.Selected }} selected{{end}}{{if $val.Disabled}} disabled{{end}}>{{$val.Label}}</option>

--- a/textwidget.go
+++ b/textwidget.go
@@ -12,6 +12,7 @@ type TextWidget struct {
 type parameter struct {
 	Name  string
 	Attrs map[string]string
+	Value []string
 }
 
 func (self *TextWidget) html(field Field, vs ...string) string {
@@ -19,6 +20,7 @@ func (self *TextWidget) html(field Field, vs ...string) string {
 	Template.ExecuteTemplate(&buffer, "TextWidget", parameter{
 		Attrs: self.Attrs,
 		Name:  field.GetName(),
+		Value: vs,
 	})
 	return buffer.String()
 }


### PR DESCRIPTION
Currently, TextWidget won't use the value from a previous submission of the form.  I'm not 100% comfortable with my solution, as the iterating to display values for a field that should likely never be an actual array seems a little hokey.  But, that's the data type getting passed to the widget, so I stuck with it.

Here was my example form that I triggered this with:

	loginForm := gforms.DefineForm(gforms.NewFields(
		gforms.NewTextField("Username",
			gforms.Validators{
				gforms.Required(),
			},
			gforms.NewTextWidget(map[string]string{"class": "form-control"}),
		),
		gforms.NewTextField("Password",
			gforms.Validators{
				gforms.Required(),
			},
			gforms.NewTextWidget(map[string]string{"class": "form-control"}),
		),
	))
