### PR TITLE
Support for a valid nullable boolean field type

### DIFF
--- a/nullbooleanfield.go
+++ b/nullbooleanfield.go
@@ -1,0 +1,82 @@
+package gforms
+
+import (
+	"bytes"
+	"reflect"
+)
+
+// It maps value to FormInstance.CleanedData as type `bool`.
+type NullBooleanField struct {
+	BaseField
+}
+
+// Create a new NullBooleanField instance.
+func (f *NullBooleanField) New() FieldInterface {
+	fi := new(NullBooleanFieldInstance)
+	fi.Model = f
+	fi.V = nilV("")
+	return fi
+}
+
+// Instance for NullBooleanField.
+type NullBooleanFieldInstance struct {
+	FieldInstance
+}
+
+type nullBooleanContext struct {
+	Field   FieldInterface
+	Checked bool
+}
+
+// Create a new NullBooleanField with validators and widgets.
+func NewNullBooleanField(name string, vs Validators, ws ...Widget) *NullBooleanField {
+	f := new(NullBooleanField)
+	f.name = name
+	f.validators = vs
+	if len(ws) > 0 {
+		f.widget = ws[0]
+	}
+	return f
+}
+
+// Get a value from request data, and clean it as type `bool`.
+func (f *NullBooleanFieldInstance) Clean(data Data) error {
+	m, hasField := data[f.GetName()]
+	if hasField {
+		f.V = m
+		v := false
+		if m.Kind == reflect.String {
+			vs := m.rawValueAsString()
+			if vs != nil {
+				v = true
+			}
+		} else if m.Kind == reflect.Bool {
+			v = m.rawValueAsBool()
+		}
+		m.Value = v
+		m.Kind = reflect.Bool
+		m.IsNil = false
+		return nil
+	}
+	nv := nilV("")
+	f.V = nv
+	return nil
+}
+
+func (f *NullBooleanFieldInstance) html() string {
+	var buffer bytes.Buffer
+	cx := new(nullBooleanContext)
+	cx.Field = f
+	checked, _ := f.V.Value.(bool)
+	cx.Checked = checked
+	err := Template.ExecuteTemplate(&buffer, "BooleanTypeField", cx)
+	if err != nil {
+		panic(err)
+	}
+	return buffer.String()
+}
+
+// Get as HTML format.
+func (f *NullBooleanFieldInstance) Html() string {
+	return fieldToHtml(f)
+}

--- a/nullbooleanfield_test.go
+++ b/nullbooleanfield_test.go
@@ -1,0 +1,96 @@
+package gforms
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type testNullBooleanObject struct {
+	Check bool `gforms:"check"`
+}
+
+func TestTrueNullBooleanField(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewNullBooleanField("check", nil),
+	))
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(url.Values{"check": {"true"}}.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	form := Form(req)
+	if form.IsValid() {
+		v, ok := form.CleanedData["check"]
+		if !ok {
+			t.Error(`"check" is required.`)
+			return
+		}
+		_, ok = v.(bool)
+		if !ok {
+			t.Error(`"check" should be boolean type.`)
+			return
+		}
+		obj := new(testNullBooleanObject)
+		form.MapTo(obj)
+		if obj.Check == false {
+			t.Error(`"obj.Check" should not be false.`)
+		}
+	} else {
+		t.Error("validation error.")
+	}
+}
+
+func TestFalseNullBooleanField(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewNullBooleanField("check", nil),
+	))
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(url.Values{"check": {"false"}}.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	form := Form(req)
+	if form.IsValid() {
+		v, ok := form.CleanedData["check"]
+		if !ok {
+			t.Error(`"check" is required.`)
+			return
+		}
+		_, ok = v.(bool)
+		if !ok {
+			t.Error(`"check" should be boolean type.`)
+			return
+		}
+		obj := new(testNullBooleanObject)
+		form.MapTo(obj)
+		if obj.Check == false {
+			t.Error(`"obj.Check" should be false.`)
+		}
+	} else {
+		t.Error("validation error.")
+	}
+}
+
+func TestFalseNullBooleanFieldEmpty(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewNullBooleanField("check", nil),
+	))
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(url.Values{}.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	form := Form(req)
+	if form.IsValid() {
+		_, ok := form.CleanedData["check"]
+		if ok {
+			t.Error(`"check" should not exist.`)
+			return
+		}
+	}
+}
+
+func TestTrueNullBooleanFieldJsonRequired(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewNullBooleanField("check", Validators{Required()}),
+	))
+	req, _ := http.NewRequest("POST", "/", strings.NewReader("{}"))
+	req.Header.Add("Content-Type", "application/json")
+	form := Form(req)
+	if form.IsValid() {
+		t.Error("Null boolean field should be required.")
+	}
+}


### PR DESCRIPTION
Especially when doing JSON, having a boolean type field that you want to support a "Required" validation check on is not possible with the current BooleanFIeld.  I can see that as a valid use case, and so I did not try to overload that field with nullable functionality.  Instead, I've created a separate NullBooleanField that can be safely nil, and passes Required validation tests.  Tests included.  Issue #6 