### PR TITLE
Boolean fields need a SetInitial that correctly parses a boolean value for Checked.

### DIFF
--- a/booleanfield.go
+++ b/booleanfield.go
@@ -3,6 +3,7 @@ package gforms
 import (
 	"bytes"
 	"reflect"
+	"strconv"
 )
 
 // It maps value to FormInstance.CleanedData as type `bool`.
@@ -63,6 +64,18 @@ func (f *BooleanFieldInstance) Clean(data Data) error {
 	nv.IsNil = false
 	f.V = nv
 	return nil
+}
+
+func (f *BooleanFieldInstance) SetInitial(v string) {
+	f.V.RawStr = v
+	f.V.RawValue = []string{v}
+	f.V.IsNil = false
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		f.V.IsNil = true
+	} else {
+		f.V.Value = b
+	}
 }
 
 func (f *BooleanFieldInstance) html() string {

--- a/booleanfield_test.go
+++ b/booleanfield_test.go
@@ -66,3 +66,43 @@ func TestFalseBooleanField(t *testing.T) {
 		t.Error("validation error.")
 	}
 }
+
+func TestBooleanFieldDefaultRender(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewBooleanField("check", nil),
+	))
+	form := Form()
+	html := strings.TrimSpace(form.Html())
+	if html != `<input type="checkbox" name="check">` {
+		t.Errorf(`Incorrect HTML rendered for default boolean field: %s`, html)
+		return
+	}
+}
+
+func TestBooleanFieldInitialFalseRender(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewBooleanField("check", nil),
+	))
+	form := Form()
+	field, _ := form.GetField("check")
+	field.SetInitial("false")
+	html := strings.TrimSpace(form.Html())
+	if html != `<input type="checkbox" name="check">` {
+		t.Errorf(`Incorrect HTML rendered for SetInitial("false") boolean field: %s`, html)
+		return
+	}
+}
+
+func TestBooleanFieldInitialTrueRender(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewBooleanField("check", nil),
+	))
+	form := Form()
+	field, _ := form.GetField("check")
+	field.SetInitial("true")
+	html := strings.TrimSpace(form.Html())
+	if html != `<input type="checkbox" name="check" checked>` {
+		t.Errorf(`Incorrect HTML rendered for SetInitial("true") boolean field: %s`, html)
+		return
+	}
+}

--- a/nullbooleanfield.go
+++ b/nullbooleanfield.go
@@ -3,6 +3,7 @@ package gforms
 import (
 	"bytes"
 	"reflect"
+	"strconv"
 )
 
 // It maps value to FormInstance.CleanedData as type `bool`.
@@ -61,6 +62,18 @@ func (f *NullBooleanFieldInstance) Clean(data Data) error {
 	nv := nilV("")
 	f.V = nv
 	return nil
+}
+
+func (f *NullBooleanFieldInstance) SetInitial(v string) {
+	f.V.RawStr = v
+	f.V.RawValue = []string{v}
+	f.V.IsNil = false
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		f.V.IsNil = true
+	} else {
+		f.V.Value = b
+	}
 }
 
 func (f *NullBooleanFieldInstance) html() string {

--- a/nullbooleanfield_test.go
+++ b/nullbooleanfield_test.go
@@ -94,3 +94,43 @@ func TestTrueNullBooleanFieldJsonRequired(t *testing.T) {
 		t.Error("Null boolean field should be required.")
 	}
 }
+
+func TestNullBooleanFieldDefaultRender(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewNullBooleanField("check", nil),
+	))
+	form := Form()
+	html := strings.TrimSpace(form.Html())
+	if html != `<input type="checkbox" name="check">` {
+		t.Errorf(`Incorrect HTML rendered for default null boolean field: %s`, html)
+		return
+	}
+}
+
+func TestNullBooleanFieldInitialFalseRender(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewNullBooleanField("check", nil),
+	))
+	form := Form()
+	field, _ := form.GetField("check")
+	field.SetInitial("false")
+	html := strings.TrimSpace(form.Html())
+	if html != `<input type="checkbox" name="check">` {
+		t.Errorf(`Incorrect HTML rendered for SetInitial("false") null boolean field: %s`, html)
+		return
+	}
+}
+
+func TestNullBooleanFieldInitialTrueRender(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewNullBooleanField("check", nil),
+	))
+	form := Form()
+	field, _ := form.GetField("check")
+	field.SetInitial("true")
+	html := strings.TrimSpace(form.Html())
+	if html != `<input type="checkbox" name="check" checked>` {
+		t.Errorf(`Incorrect HTML rendered for SetInitial("true") null boolean field: %s`, html)
+		return
+	}
+}


### PR DESCRIPTION
SetInitial currently does not work for boolean fields, leading to checkboxes that aren't checked in rendering.

I've also put in some tests for various boolean checkbox renderings that show the previous behavior not checking the box for some SetInitial combinations.