### PR TITLE
DateTimeField requires input even when there are no Required validators

### DIFF
--- a/datetimefield.go
+++ b/datetimefield.go
@@ -58,7 +58,7 @@ func (f *DateTimeFieldInstance) Clean(data Data) error {
 		f.V = m
 		v := m.rawValueAsString()
 		m.Kind = reflect.Struct
-		if v != nil {
+		if v != nil && *v != "" {
 			t, err := time.Parse(f.Format, *v)
 			if err != nil {
 				return errors.New(f.ErrorMessage)

--- a/datetimefield_test.go
+++ b/datetimefield_test.go
@@ -99,3 +99,18 @@ func TestInputValidDateTimeFormat(t *testing.T) {
 		t.Error("given: " + obj.Date.String() + ", exptected: " + DefaultDateTimeFormat)
 	}
 }
+
+func TestInputDateNotRequired(t *testing.T) {
+	Form := DefineForm(NewFields(
+		NewDateTimeField("date", DefaultDateFormat, nil),
+	))
+	reqDate := ""
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(url.Values{"date": {reqDate}}.Encode()))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	form := Form(req)
+	if !form.IsValid() {
+		t.Error("Date required when it should not be.")
+		return
+	}
+}


### PR DESCRIPTION
DateTimeFields do not allow for blank input when the validator is set to nil.  This pull request should allow for empty inputs on that field, and let the Required validator work as per usual.

Tests included!